### PR TITLE
Fixed most issues with viewer, multiple rows need scrubber

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 
 <link href="https://code.jquery.com/jquery-2.2.4.min.js">
 <!-- jQuery 2.2.4 -->
+<script src="wikipediaAPI.js"></script>
 <script>
 	$(document).ready(function() {
 	<!--Tell user not to use https-->
@@ -28,7 +29,8 @@
 	  $("#searchQuery").on("keypress", function(event) {
 	    if (event.keyCode == 13) {
 	      var x = document.getElementById("searchQuery");
-	      var apiUrl = "http://en.wikipedia.org/w/api.php?format=json&action=query&titles=" + encodeURIComponent(x.value) + "&prop=extracts&rvprop=content&indexpageids=&redirects=1&callback=?";
+	      var apiUrl = "http://en.wikipedia.org/w/api.php?format=json&action=query&titles=" + encodeURIComponent(x.value) +
+	       "&prop=extracts&rvprop=content&indexpageids=&redirects=1&exintro=&callback=?";
 	      console.log(apiUrl);
 	      $.getJSON(apiUrl, function(inJson) {
 	        displayWiki(inJson);
@@ -37,9 +39,6 @@
 	  });
 	});
 
-function displayWiki(wikiJson) {
-  alert(JSON.stringify(wikiJson));
-}
 </script>
 
 <html>

--- a/index.html
+++ b/index.html
@@ -7,22 +7,32 @@
 	.frontFace {
 	  font-family: helvetica;
 	}
+
+	#results {
+	  background-color: #b3b5b4
+	}
 </style>
 
 <link href="https://code.jquery.com/jquery-2.2.4.min.js">
 <!-- jQuery 2.2.4 -->
 <script>
 	$(document).ready(function() {
-	  	$("#searchQuery").on("keypress", function(event) {
-		    if (event.keyCode == 13) {
-		      alert("Enter was pressed");
-		      var x = document.getElementById("searchQuery");
-		      alert(encodeURIComponent(x.value));
-		      var apiUrl = "http://en.wikipedia.org/w/api.php?format=json&action=query&titles="+ encodeURIComponent(x.value)+"&prop=extracts&rvprop=content&callback=?";
-		      console.log(apiUrl);
-		      $.getJSON(apiUrl, function(inJson){
-		        alert(inJson);
-		      });
+	<!--Tell user not to use https-->
+
+	  if (window.location.protocol == "https:") {
+	    $("#results").html("");
+	    alert("You are using https. We can't access wikipedia if https is used. Please access this page using http. You can do this by changing the 'https' in your addressbar into 'http'.");
+	  };
+
+	  <!-- If enter is pressed, search wikipedia and display results-->
+	  $("#searchQuery").on("keypress", function(event) {
+	    if (event.keyCode == 13) {
+	      var x = document.getElementById("searchQuery");
+	      var apiUrl = "http://en.wikipedia.org/w/api.php?format=json&action=query&titles=" + encodeURIComponent(x.value) + "&prop=extracts&rvprop=content&indexpageids=&redirects=1&callback=?";
+	      console.log(apiUrl);
+	      $.getJSON(apiUrl, function(inJson) {
+	        displayWiki(inJson);
+	      });
 	    };
 	  });
 	});

--- a/wikipediaAPI.js
+++ b/wikipediaAPI.js
@@ -6,6 +6,8 @@ function displayWiki(wikiJson) {
     var title = wikiJson["query"]["pages"][pagesArray[i]]["title"];
     var extract = wikiJson["query"]["pages"][pagesArray[i]]["extract"];
     $("#results").html("")
-    $("#results").append("<div class=row><a href=http://en.wikipedia.org/?curid="+ pagesArray[i]+">" + title + "</a> " + extract + "</div>");
+    $("#results").append(
+    	"<div class=row><a href=http://en.wikipedia.org/?curid="+ 
+    	pagesArray[i]+">" + title + "</a> " + extract + "</div>");
   }
 }

--- a/wikipediaAPI.js
+++ b/wikipediaAPI.js
@@ -1,13 +1,14 @@
 
-// function will display the data from a wiki page. (Put a new function to put data in rows)
+// function will display the data from a wiki page. 
+// (Put a new function to put data in rows)
 function displayWiki(wikiJson) {
   var pagesArray = wikiJson["query"]["pageids"];
-  for(var i = 0; i < pagesArray.length; i++){
+  $("#results").html("")
+  for (var i = 0; i < pagesArray.length; i++) {
     var title = wikiJson["query"]["pages"][pagesArray[i]]["title"];
     var extract = wikiJson["query"]["pages"][pagesArray[i]]["extract"];
-    $("#results").html("")
     $("#results").append(
-    	"<div class=row><a href=http://en.wikipedia.org/?curid="+ 
-    	pagesArray[i]+">" + title + "</a> " + extract + "</div>");
+    	"<div class=row><a href=http://en.wikipedia.org/?curid=" 
+    	+ pagesArray[i] + ">" + title + "</a> " + extract + "</div>");
   }
 }


### PR DESCRIPTION
- Wikipedia results should display properly, with a short description of what is searched.
  -Some disambiguations do not work (ex. searching joker yields very little)

-In order to satisfy issue #1 , we have to use something other than exintro, since exintro doesn't return hyperlinks. We could use a link scrubber to do this.
